### PR TITLE
update tarojs nextjs plugin & fix global css in page

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "taro-ui": "^3.1.0-beta.2",
-    "tarojs-plugin-platform-nextjs": "^2.0.7"
+    "tarojs-plugin-platform-nextjs": "^2.0.9"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 import { Component, PropsWithChildren } from 'react'
-import './app.less'
+import 'taro-ui/dist/style/index.scss'
 
 class App extends Component<PropsWithChildren> {
 

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -1,9 +1,7 @@
 import { Component, PropsWithChildren } from 'react'
 import { View, Text } from '@tarojs/components'
 import { AtButton } from 'taro-ui'
-
-import "taro-ui/dist/style/components/button.scss" // 按需引入
-import './index.less'
+import './index.module.less'
 
 export default class Index extends Component<PropsWithChildren> {
   componentDidMount () { }
@@ -20,9 +18,9 @@ export default class Index extends Component<PropsWithChildren> {
         <Text>Hello world! 123</Text>
         <AtButton type='primary'>I need Taro UI</AtButton>
         <Text>Taro UI 支持 Vue 了吗？</Text>
-        <AtButton type='primary' circle={true}>支持</AtButton>
+        <AtButton type='primary' circle>支持</AtButton>
         <Text>共建？</Text>
-        <AtButton type='secondary' circle={true}>来</AtButton>
+        <AtButton type='secondary' circle>来</AtButton>
       </View>
     )
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13115,10 +13115,10 @@ taro-ui@^3.1.0-beta.2:
     prop-types "^15.7.2"
     react-native-modal "^13.0.0"
 
-tarojs-plugin-platform-nextjs@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/tarojs-plugin-platform-nextjs/-/tarojs-plugin-platform-nextjs-2.0.7.tgz#600adc152f91182d674aedafa2e8521e5183b21e"
-  integrity sha512-8xpBYU/aJDUDyRsddRsI8yi9ar3ACQH5UH1A8TdHyhB81wZXQoO8QkwxtweFQVbIOQlvGBa50a4605NguNU35Q==
+tarojs-plugin-platform-nextjs@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.npmjs.org/tarojs-plugin-platform-nextjs/-/tarojs-plugin-platform-nextjs-2.0.9.tgz#1e3ede71cc3e953d59e9fe071c2af2ae8fc01ec1"
+  integrity sha512-2gcUgok72vPDaNTl9Xh1hl4ATJp121DPIxDLyVt6vUazthAhugUHMIkMWif+zU66ig8KxEFFYw2QD0X1eVxb1A==
   dependencies:
     "@babel/core" "^7.17.7"
     "@babel/helper-split-export-declaration" "^7.16.7"


### PR DESCRIPTION
1. 升级 Taro Next.js 插件。
2. Fix 不能在 Page 组件中使用 global css。